### PR TITLE
Updated Mire in 1.21.4

### DIFF
--- a/src/main/generated/data/aylyth/tags/block/pool_neighboring.json
+++ b/src/main/generated/data/aylyth/tags/block/pool_neighboring.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:grass_block",
+    "minecraft:mud",
+    "minecraft:podzol",
+    "minecraft:soul_soil",
+    "aylyth:dark_podzol",
+    "minecraft:water"
+  ]
+}

--- a/src/main/generated/data/aylyth/worldgen/biome/mire.json
+++ b/src/main/generated/data/aylyth/worldgen/biome/mire.json
@@ -23,32 +23,33 @@
     "water_fog_color": 0
   },
   "features": [
-    [],
-    [],
-    [],
-    [],
-    [],
-    [],
     [
       "minecraft:ore_iron_upper",
       "minecraft:ore_iron_middle",
       "minecraft:ore_iron_small",
       "minecraft:ore_copper"
     ],
-    [],
-    [],
+    [
+      "minecraft:patch_grass_badlands"
+    ],
+    [
+      "aylyth:mire_floor_pool"
+    ],
+    [
+      "aylyth:mire_pools"
+      ],
+    [
+      "aylyth:woody_growth_water_patch",
+      "aylyth:small_woody_growth_water",
+      "aylyth:antler_shoots_water_patch",
+      "aylyth:mire_water_trees"
+    ],
     [
       "aylyth:spruce_seep",
       "aylyth:aylyth_weeds",
-      "aylyth:woody_growth_patch",
       "minecraft:patch_large_fern",
-      "aylyth:woody_growth_water_patch",
-      "aylyth:antler_shoots_water_patch",
-      "aylyth:antler_shoots_patch",
       "aylyth:strewn_leaves_patch",
-      "aylyth:mire_water_trees",
-      "aylyth:mire_land_trees",
-      "minecraft:patch_grass_badlands"
+      "aylyth:mire_land_trees"
     ]
   ],
   "has_precipitation": true,

--- a/src/main/generated/data/aylyth/worldgen/configured_feature/mire_floor_pool.json
+++ b/src/main/generated/data/aylyth/worldgen/configured_feature/mire_floor_pool.json
@@ -1,0 +1,4 @@
+{
+  "type": "aylyth:mire_floor_pool",
+  "config": {}
+}

--- a/src/main/generated/data/aylyth/worldgen/configured_feature/mire_pools.json
+++ b/src/main/generated/data/aylyth/worldgen/configured_feature/mire_pools.json
@@ -1,0 +1,4 @@
+{
+  "type": "aylyth:mire_pools",
+  "config": {}
+}

--- a/src/main/generated/data/aylyth/worldgen/noise_settings/aylyth_settings.json
+++ b/src/main/generated/data/aylyth/worldgen/noise_settings/aylyth_settings.json
@@ -26,8 +26,8 @@
     "depth": "aylyth:depth",
     "erosion": "aylyth:erosion",
     "final_density": "aylyth:density_final",
-    "fluid_level_floodedness": "aylyth:aquifer_fluid_floodedness",
-    "fluid_level_spread": "aylyth:aquifer_fluid_spread",
+    "fluid_level_floodedness": 0.0,
+    "fluid_level_spread": 0.0,
     "initial_density_without_jaggedness": "aylyth:density_initial_without_jaggedness",
     "lava": 0.0,
     "ridges": "aylyth:ridges",
@@ -38,7 +38,7 @@
     "vein_toggle": 0.0
   },
   "ore_veins_enabled": false,
-  "sea_level": 47,
+  "sea_level": 31,
   "spawn_target": [],
   "surface_rule": {
     "type": "minecraft:sequence",

--- a/src/main/generated/data/aylyth/worldgen/placed_feature/antler_shoots_water_patch.json
+++ b/src/main/generated/data/aylyth/worldgen/placed_feature/antler_shoots_water_patch.json
@@ -6,7 +6,7 @@
     },
     {
       "type": "minecraft:surface_water_depth_filter",
-      "max_water_depth": 2
+      "max_water_depth": 16
     },
     {
       "type": "minecraft:heightmap",

--- a/src/main/generated/data/aylyth/worldgen/placed_feature/mire_floor_pool.json
+++ b/src/main/generated/data/aylyth/worldgen/placed_feature/mire_floor_pool.json
@@ -1,0 +1,12 @@
+{
+  "feature": "aylyth:mire_floor_pool",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 32
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/generated/data/aylyth/worldgen/placed_feature/mire_pools.json
+++ b/src/main/generated/data/aylyth/worldgen/placed_feature/mire_pools.json
@@ -1,0 +1,24 @@
+{
+  "feature": "aylyth:mire_pools",
+  "placement": [
+    {
+      "type": "minecraft:count_on_every_layer",
+      "count": 256
+    },
+    {
+      "type": "minecraft:random_offset",
+      "xz_spread": {
+        "type": "minecraft:uniform",
+        "min_inclusive": 1,
+        "max_inclusive": 14
+      },
+      "y_spread": {
+        "type": "minecraft:constant",
+        "value": 0
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/generated/data/aylyth/worldgen/placed_feature/mire_water_trees.json
+++ b/src/main/generated/data/aylyth/worldgen/placed_feature/mire_water_trees.json
@@ -22,7 +22,7 @@
     },
     {
       "type": "minecraft:surface_water_depth_filter",
-      "max_water_depth": 3
+      "max_water_depth": 6
     },
     {
       "type": "minecraft:heightmap",

--- a/src/main/java/moriyashiine/aylyth/common/data/tag/AylythBlockTags.java
+++ b/src/main/java/moriyashiine/aylyth/common/data/tag/AylythBlockTags.java
@@ -2,7 +2,6 @@ package moriyashiine.aylyth.common.data.tag;
 
 import moriyashiine.aylyth.common.Aylyth;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;

--- a/src/main/java/moriyashiine/aylyth/common/data/tag/AylythBlockTags.java
+++ b/src/main/java/moriyashiine/aylyth/common/data/tag/AylythBlockTags.java
@@ -24,6 +24,7 @@ public interface AylythBlockTags {
     TagKey<Block> BRANCHES = bind("branches");
     TagKey<Block> LEAFY_BRANCHES = bind("branches/leafy");
     TagKey<Block> BARE_BRANCHES = bind("branches/bare");
+    TagKey<Block> POOL_NEIGHBORING = bind("pool_neighboring");
 
     TagKey<Block> STORAGE_BLOCKS_ESSTLINE = bindC("storage_blocks/esstline");
     TagKey<Block> STORAGE_BLOCKS_NEPHRITE = bindC("storage_blocks/nephrite");

--- a/src/main/java/moriyashiine/aylyth/common/world/gen/AylythFeatures.java
+++ b/src/main/java/moriyashiine/aylyth/common/world/gen/AylythFeatures.java
@@ -1,14 +1,7 @@
 package moriyashiine.aylyth.common.world.gen;
 
 import moriyashiine.aylyth.common.Aylyth;
-import moriyashiine.aylyth.common.world.gen.features.AllFeature;
-import moriyashiine.aylyth.common.world.gen.features.BushFeature;
-import moriyashiine.aylyth.common.world.gen.features.DoubleBlockFeature;
-import moriyashiine.aylyth.common.world.gen.features.GiantMushroomFeature;
-import moriyashiine.aylyth.common.world.gen.features.HorizontalFacingFeature;
-import moriyashiine.aylyth.common.world.gen.features.LeafPileFeature;
-import moriyashiine.aylyth.common.world.gen.features.SeepFeature;
-import moriyashiine.aylyth.common.world.gen.features.SpringFeature;
+import moriyashiine.aylyth.common.world.gen.features.*;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.world.gen.feature.Feature;
@@ -23,6 +16,8 @@ public interface AylythFeatures {
     HorizontalFacingFeature HORIZONTAL_FACING_FEATURE = register("horizontal_facing", new HorizontalFacingFeature());
     DoubleBlockFeature DOUBLE_BLOCK_FEATURE = register("double_block", new DoubleBlockFeature());
     GiantMushroomFeature GIANT_MUSHROOM = register("giant_mushroom", new GiantMushroomFeature(GiantMushroomFeature.GiantMushroomConfig.CODEC));
+    MirePoolsFeature MIRE_POOLS_FEATURE = register("mire_pools", new MirePoolsFeature());
+    MireFloorPoolFeature MIRE_FLOOR_POOL_FEATURE = register("mire_floor_pool", new MireFloorPoolFeature());
     AllFeature ALL = register("all", new AllFeature(AllFeature.AllFeatureConfig.CODEC));
 
     private static <C extends FeatureConfig, F extends Feature<C>> F register(String name, F feature) {

--- a/src/main/java/moriyashiine/aylyth/common/world/gen/features/MireFloorPoolFeature.java
+++ b/src/main/java/moriyashiine/aylyth/common/world/gen/features/MireFloorPoolFeature.java
@@ -1,6 +1,5 @@
 package moriyashiine.aylyth.common.world.gen.features;
 
-import moriyashiine.aylyth.common.data.tag.AylythBlockTags;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/moriyashiine/aylyth/common/world/gen/features/MireFloorPoolFeature.java
+++ b/src/main/java/moriyashiine/aylyth/common/world/gen/features/MireFloorPoolFeature.java
@@ -1,0 +1,46 @@
+package moriyashiine.aylyth.common.world.gen.features;
+
+import moriyashiine.aylyth.common.data.tag.AylythBlockTags;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.gen.feature.DefaultFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+public class MireFloorPoolFeature extends Feature<DefaultFeatureConfig> {
+    public MireFloorPoolFeature() {
+        super(DefaultFeatureConfig.CODEC);
+    }
+
+    @Override
+    public boolean generate(FeatureContext<DefaultFeatureConfig> context) {
+        StructureWorldAccess world = context.getWorld();
+        BlockPos origin = context.getOrigin();
+
+        int floorY = 36;
+        int floorYMin = 24;
+        int floorRadius = 12;
+        boolean placedAny = false;
+
+        for (int dx = -floorRadius; dx <= floorRadius; dx++) {
+            for (int dz = -floorRadius; dz <= floorRadius; dz++) {
+                if (dx * dx + dz * dz > floorRadius * floorRadius) continue;
+
+                for (int y = floorYMin; y <= floorY; y++) {
+                    BlockPos pos = new BlockPos(origin.getX() + dx, y, origin.getZ() + dz);
+                    BlockState state = world.getBlockState(pos);
+                    if (state.isAir()) {
+                        BlockState waterState = Blocks.WATER.getDefaultState();
+                        world.setBlockState(pos, waterState, 3);
+                        world.scheduleFluidTick(pos, waterState.getFluidState().getFluid(), 10);
+                        placedAny = true;
+                    }
+                }
+            }
+        }
+
+        return placedAny;
+    }
+}

--- a/src/main/java/moriyashiine/aylyth/common/world/gen/features/MirePoolsFeature.java
+++ b/src/main/java/moriyashiine/aylyth/common/world/gen/features/MirePoolsFeature.java
@@ -1,0 +1,62 @@
+package moriyashiine.aylyth.common.world.gen.features;
+
+import moriyashiine.aylyth.common.data.tag.AylythBlockTags;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.gen.feature.DefaultFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+public class MirePoolsFeature extends Feature<DefaultFeatureConfig> {
+    public MirePoolsFeature() {
+        super(DefaultFeatureConfig.CODEC);
+    }
+
+    @Override
+    public boolean generate(FeatureContext<DefaultFeatureConfig> context) {
+        StructureWorldAccess world = context.getWorld();
+        BlockPos origin = context.getOrigin();
+
+        int radius = 2;
+        boolean placedAny = false;
+
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dz = -radius; dz <= radius; dz++) {
+                if (dx * dx + dz * dz > radius * radius) continue;
+
+                BlockPos pos = origin.add(dx, 0, dz);
+                BlockState state = world.getBlockState(pos);
+
+                if (state.isIn(AylythBlockTags.POOL_NEIGHBORING)
+                        && (world.isAir(pos.up())) //|| world.getBlockState(pos.up()).isOf(Blocks.WATER))
+                        && isSurroundedBySolid(world, pos)
+                        && context.getRandom().nextFloat() < 0.7f) {
+                    BlockState waterState = Blocks.WATER.getDefaultState();
+                    world.setBlockState(pos, waterState, 3);
+                    world.scheduleFluidTick(pos, waterState.getFluidState().getFluid(), 10);
+                    placedAny = true;
+                }
+            }
+        }
+
+        return placedAny;
+    }
+
+    private boolean isSurroundedBySolid(StructureWorldAccess world, BlockPos pos) {
+        BlockState down = world.getBlockState(pos.down());
+        BlockState current = world.getBlockState(pos);
+
+        if (!down.isIn(AylythBlockTags.POOL_NEIGHBORING)) return false;
+        if (!current.isAir() && !current.isIn(AylythBlockTags.POOL_NEIGHBORING)) return false;
+
+        int solidCount = 0;
+        if (world.getBlockState(pos.north()).isIn(AylythBlockTags.POOL_NEIGHBORING)) solidCount++;
+        if (world.getBlockState(pos.south()).isIn(AylythBlockTags.POOL_NEIGHBORING)) solidCount++;
+        if (world.getBlockState(pos.east()).isIn(AylythBlockTags.POOL_NEIGHBORING)) solidCount++;
+        if (world.getBlockState(pos.west()).isIn(AylythBlockTags.POOL_NEIGHBORING)) solidCount++;
+
+        return solidCount >= 4;
+    }
+}


### PR DESCRIPTION
-Filled air in the mire with water at and below y=36

-Added water shelves/pools to the side of the mire

-Tweaked mire feature spawn order and which ones are placed, only the short growths can be deep underwater, there is still a 25% chance for a tall one in shallow water, trees and antler shoots go deeper underwater. 

-Removed oceans again since its not on git yet


notes:
the height of the mire is quite varied so sometimes 36 is too low sometimes it could be almost too high
they shouldn't but rarely the standard taiga still spawns in water from the mire_land_trees